### PR TITLE
Create projection embeddings for wandb

### DIFF
--- a/awk.x
+++ b/awk.x
@@ -1,0 +1,3 @@
+# Utility to remove wandb processes from ps -elf
+
+ps -elf | grep 'wandb' | awk '{print $4}' | xargs kill -9

--- a/run_wandb.x
+++ b/run_wandb.x
@@ -1,0 +1,8 @@
+python main.py \
+    --nb_samples 96 \
+    --num_epochs 10 \
+    --num_layers 1 \
+    --batch_size_train 32 \
+    --batch_size_val 32 \
+    --d_model 64 \
+    --wandb

--- a/train.py
+++ b/train.py
@@ -94,6 +94,8 @@ def run_code_impl(run, ds):
         epoch, c, model, opt, MODEL_PATH, model_id, epoch_num
     )
 
+
+
     # ==== OUTER TRAINING LOOP =====
     for epoch in pbar:
         print("************* epoch: ", epoch, " *******************88")
@@ -102,6 +104,8 @@ def run_code_impl(run, ds):
         if c.max_nb_steps < 0:
             metrics.update(more_metrics)
         run.log(metrics)
+        # Log the embeddings
+        train_impl.log_embeddings(model, ds)
         save_fct(epoch)
 
     # 🐝 Close wandb 

--- a/train_impl.py
+++ b/train_impl.py
@@ -361,4 +361,32 @@ def create_data_slices(cutpoint, c, ds):
 def print_weight_norms(model, msg):
     norm = pt.sqrt(sum([pt.norm(w[0], p=2) ** 2 for w in model.parameters()]))
     print(f"==> {msg}, {norm}")
+
+#----------------------------------------------------------------------
+def log_embeddings(model, ds):
+    """
+    Extract the embedding layer from the model: one for orthography, one for phonology. 
+    This is used to visualize the embeddings in wandb
+    """
+
+    orth_embedding_layer = model.orthography_embedding
+    phon_embedding_layer = model.phonology_embedding
+    orth_embed_weights = orth_embedding_layer.weight.detach().data
+    phon_embed_weights = phon_embedding_layer.weight.detach().data
+    print("orth_embed_weights shape: ", orth_embed_weights.shape)
+    print("phon_embed_weights shape: ", phon_embed_weights.shape)
+    print("phon_embed_weights type: ", type(phon_embed_weights))
+    #wandb.log({"hist_embeddings": [wandb.Histogram(orth_embed_weights), wandb.Histogram(phon_embed_weights)]})
+    # log the embeddings as two tables: one for orthography, one for phonology
+
+    def fill_table(A):
+        n, m = A.numpy().shape
+        columns = ['col'+str(i) for i in range(m)]
+        return wandb.Table(data=A.numpy().tolist(), columns=columns)
+
+    orth_embed_table = fill_table(orth_embed_weights)
+    phon_embed_table = fill_table(orth_embed_weights)
+
+    wandb.log({"orth_embed_table": orth_embed_table, "phon_embed_table": phon_embed_table})
+
 #----------------------------------------------------------------------

--- a/wandb_wrapper.py
+++ b/wandb_wrapper.py
@@ -89,6 +89,12 @@ class WandbWrapper(Singleton):
             return wandb.Table(*kargs, **kwargs)  # Recursion. Why?
         else:
             return self.my_table
+        
+    def Histogram(self, *kargs, **kwargs):
+        if self.is_wandb_on and self.run:
+            return wandb.Histogram(*kargs, **kwargs)  # Recursion. Why?
+        else:
+            return self.my_table  # empty proxy
 
     def sweep(self, *kargs, **kwargs):
         if len(kargs) > 0:


### PR DESCRIPTION
Fixes #32
awk.x: script to remove wandb background processes
run_wandb.x: the run I am testing on
wandb_wrapper.py: handles wandb.Histogram
train.py: fcall to train_impl.log_embeddings, once per epoch
train_impl.py: added the function log_embeddings