### PR TITLE
give ci runner the cmudict data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,7 @@ jobs:
           key: venv-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
         run: poetry install
+      - name: Download NLTK data
+        run: poetry run python -c "import nltk; nltk.download('cmudict')"
       - name: Run unit tests
         run: poetry run pytest -v


### PR DESCRIPTION
tests pass locally but not in the CI pipeline. Looks like the runners need the cmudict dataste. I added a step to the ci.yml to download it.