### PR TITLE
PYTHONPATH is not defined in base image

### DIFF
--- a/.devcontainer/Dockerfile.cpu.dev
+++ b/.devcontainer/Dockerfile.cpu.dev
@@ -38,4 +38,4 @@ RUN poetry install --no-root --no-interaction
 COPY . .
 
 # Set Python path
-ENV PYTHONPATH="${PYTHONPATH}:/app"
+ENV PYTHONPATH="/app"


### PR DESCRIPTION
Building resulted in an error

`UndefinedVar: Usage of undefined variable '$PYTHONPATH'`

It is not defined in the base python image.